### PR TITLE
Fix submodule not uploaded issue

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,10 @@ jobs:
                 --upgrade 
                 build
 
+            - name: Initialize submodules
+              run: |
+                git submodule update --init
+
             - name: Build SDist and wheel
               run: python3 -m build
 

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,14 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+
+sphinx:
+  fail_on_warning: true
+  configuration: docs/source/conf.py
+
+formats:
+  - pdf
+  - epub

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,6 @@ build:
     python: "3.11"
 
 sphinx:
-  fail_on_warning: true
   configuration: docs/source/conf.py
 
 formats:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -89,7 +89,7 @@ html_theme = 'alabaster'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,4 +33,4 @@ AlphaPeel = "tinypeel.tinypeel:main"
 
 [tool.setuptools]
 package-dir = {"" = "src"}
-packages = ["tinypeel", "tinypeel.Peeling"]
+packages = ["tinypeel", "tinypeel.tinyhouse", "tinypeel.Peeling"]


### PR DESCRIPTION
I checked the package that is downloaded via ``pip`` and found that it does not contain the submodule ``tinyhouse``, now by the following update, the wheel generated would contain the submodule.

I also add the Read the Docs configuration file for the documentation. The [HTML](https://xingertang-alphapeel.readthedocs.io/en/latest/) page and the [pdf](https://xingertang-alphapeel.readthedocs.io/_/downloads/en/latest/pdf/) file are the sample documentations that are produced on my own repository.