### PR TITLE
Polish of the usage and TODOs to clarify and simplify options

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+[Unreleased] - 2026-02-12
+=========================
+
+Maintenance
+-----------
+
+* Updated the documentation to clarify inputs, outputs, and parameters
+  (:pr:`219`, :user:`gregorgorjanc`).
+
 [1.3.0] - 2026-02-05
 ====================
 
@@ -33,10 +42,9 @@ New features
 
     - Added ``mutation_rate`` to allow user-provided mutation rate.
 
-Add map file input (:pr:`208`, :user:`XingerTang`, :user:`gregorgorjanc`).
+* Add map file input (:pr:`208`, :user:`XingerTang`, :user:`gregorgorjanc`).
 
     - Modified ``map_file`` to enable map file input for non-hybrid mode.
-
 
 Bug fixes
 ---------
@@ -59,7 +67,6 @@ Bug fixes
 * Fix the bug that ignores the first locus while calculating the accuracy in the accuracy test
   (:pr:`208`, :user:`XingerTang`, :user:`gregorgorjanc`).
 
-
 Maintenance
 -----------
 
@@ -80,7 +87,6 @@ Maintenance
 * Move changelog to documentation; add algorithm section, add a simple example, and
   update installation instructions in the documentation
   (:pr:`208`, :user:`XingerTang`, :user:`gregorgorjanc`).
-
 
 [1.2.0] - 2025-03-21
 ====================
@@ -174,7 +180,7 @@ Maintenance
 * Updates the documentation and help functions
   (:pr:`88`, :pr:`119`, :user:`XingerTang`, :user:`AprilYuZhang`).
 
-* Updates to accuracy and functional tests for new argument names
+* Updates to accuracy and functional tests for new option names
   (:pr:`126`, :pr:`130`, :pr:`131`, :user:`XingerTang`).
 
 [1.1.4] - 2023-08-25

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -72,6 +72,11 @@ language = "python"
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = []
 
+# Global substitutions available to all .rst files
+rst_epilog = """
+.. |Software| replace:: AlphaPeel
+"""
+
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None
 

--- a/docs/source/get_started.rst
+++ b/docs/source/get_started.rst
@@ -88,9 +88,10 @@ Install the package by using the built wheel distribution:
 
     python -m pip install dist/alphapeel*.whl
 
+.. _run-examples:
+
 Run examples
 ============
-.. _run-examples:
 
 Change the working directory to the one holding the example:
 
@@ -134,7 +135,6 @@ you may can try:
 
     git config core.fileMode false
 
-
 An example
 ----------
 
@@ -144,6 +144,8 @@ The example is deliberately simplistic for the demonstration.
 Note that |Software| can handle much more complex examples.
 The example contains two parents with known genotypes and
 one progeny with unknown genotypes.
+See the description on
+:ref:`terminology and encoding of the input data and outputs <zero_one_two_etc>`.
 
 .. image:: static/example_pedigree_with_missing.png
     :width: 20em
@@ -231,12 +233,14 @@ And following output files:
 
     simple_output.dosage.txt
     simple_output.rec_prob.txt
+TODO: Let's round up these thresholds to 0.3333333333333333 to 0.33, so 2 digits
+      This should be enough, I reckon, but happy to discuss!
     simple_output.geno_0.3333333333333333.txt
     simple_output.seq_error_prob.txt
     simple_output.geno_error_prob.txt
     simple_output.hap_0.5.txt
 
-The ``simple_output.hap_0.5.txt`` provides the called haplotype output:
+The ``simple_output.hap_0.5.txt`` provides the called haplotypes:
 
 .. code-block:: bash
 
@@ -249,10 +253,12 @@ The ``simple_output.hap_0.5.txt`` provides the called haplotype output:
 
 As you can see, each of the parents has two identical haplotypes,
 in line with their fully homozygous genotypes.
-As such, the progeny could only inherit one kind of haplotype
+As such, the progeny could only inherit one kind of a haplotype
 from each of the parents, making this a very simple example.
 
-The ``simple_output.geno_0.3333333333333333.txt`` provides the called genotype output:
+TODO: Let's round up these thresholds to 0.3333333333333333 to 0.33, so 2 digits
+      This should be enough, I reckon, but happy to discuss!
+The ``simple_output.geno_0.3333333333333333.txt`` provides the called genotypes:
 
 .. code-block:: bash
 
@@ -263,5 +269,3 @@ The ``simple_output.geno_0.3333333333333333.txt`` provides the called genotype o
 Which are just the sum of the haplotype alleles of each individual.
 
 For more information about how to use |Software|, please see :ref:`usage`.
-
-.. |Software| replace:: AlphaPeel

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,15 +11,13 @@ AlphaPeel
 |Software| is program to call, impute, and phase genotypes using a pedigree in potentially very large livestock populations. A complete description of the methods is given in Whalen et al. (2018; http://dx.doi.org/10.1186/s12711-018-0438-2).
 
 .. toctree::
-   :maxdepth: 2
-   
-   introduction
-   get_started
-   usage
-   algorithm
-   contribute
-   changelog
-   
-.. highlight:: none
+  :maxdepth: 2
 
-.. |Software| replace:: AlphaPeel
+  introduction
+  get_started
+  usage
+  algorithm
+  contribute
+  changelog
+
+.. highlight:: none

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -23,5 +23,3 @@ Disclaimer
 ----------
 
 While every effort has been made to ensure that |Software| does what it claims to do, there is absolutely no guarantee that the results provided are correct. Use of |Software| is entirely at your own risk.
-
-.. |Software| replace:: AlphaPeel

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -1,185 +1,396 @@
 .. _usage:
+
 -----
 Usage
 -----
+
+.. _program_options:
 
 ===============
 Program options
 ===============
 
-|Software| takes in several command line arguments to control the program's behaviour. To view a list of arguments, run |Software| without any command line arguments, i.e. ``AlphaPeel`` or ``AlphaPeel -h``. 
+|Software| accepts several command-line options to control the program's behaviour.
+To view a list of all supported options, run |Software| like this:
+``AlphaPeel`` or ``AlphaPeel -h``.
 
-Input arguments
----------------
+.. _input_options:
 
-::
+Input options
+-------------
 
-    Input Options:
-      -ped_file [PEDIGREE ...]
-                          Pedigree file(s) (see format below).
-      -geno_file [GENOTYPES ...]
-                          Genotype file(s) (see format below).
-      -pheno_file [PHENOTYPE ...]
-                          Phenotype file(s) (see format below).
-      -seq_file [SEQFILE ...]
-                          Sequence allele read count file(s) (see format below).
-      -plink_file [BFILE ...]
-                          Plink (binary) file(s).
-      -alt_allele_prob_file [ALT_ALLELE_PROB_FILE...]
-                          The alternative allele probabilities per metafounder(s). Default: 0.5 per marker.
-      -pheno_penetrance_file [PHENO_PENETRANCE_FILE ...]
-                          The penetrance file for the phenotypes.
+.. parsed-literal::
+
+    Individuals:
+      -ped_file [PED_FILE ...]
+                          Pedigree file(s)
+                          (:ref:`see format details <ped_file_format>`).
+      -geno_file [GENO_FILE ...]
+                          Genotype file(s)
+                          (:ref:`see format details <geno_file_format>`).
+      -seq_file [SEQ_FILE ...]
+                          Sequence allele read count file(s)
+                          (:ref:`see format details <seq_file_format>`).
+      -x_chr              Indicate that input data is for the :ref:`X chromosome <zero_one_two_etc>`.
+      -pheno_file [PHENO_FILE ...]
+                          Phenotype file(s)
+                          (:ref:`see format details <pheno_file_format>`).
+      -plink_file [PLINK_FILE ...]
+                          Plink (binary) file(s)
+                          (:ref:`see format details <plink_file_format>`).
+
+    :ref:`Markers <markers>`:
+      -map_file MAP_FILE  Map file for :ref:`loci <markers>` in genomic data files
+                          (:ref:`see format details <map_file_format>`).
       -start_snp START_SNP
-                          The first marker to consider. The first marker is "1". Default: 1.
-      -stop_snp STOP_SNP
-                          The last marker to consider. Default: all markers considered.
+                          The first :ref:`locus <markers>` to consider.
+                          Counting starts at 1.
+                          Default: 1.
+      -stop_snp STOP_SNP  The last :ref:`locus <markers>` to consider.
+                          Default: all loci in input files.
+
+    :ref:`Model parameters <prob_freq_rate>` and other:
+      -alt_allele_prob_file [ALT_ALLELE_PROB_FILE ...]
+                          Alternative allele :ref:`probability <prob_freq_rate>` file
+                          (:ref:`see format details <alt_allele_prob_file_format>`).
+                          Default: 0.5 for each locus.
       -main_metafounder MAIN_METAFOUNDER
-                          The metafounder to use where parents are unknown with input "0". Default: MF_1.
-      -map_file MAP_FILE  
-                          A map file for all loci.
+                          ID used to represent the base population of the pedigree
+                          (metafounder / unknown parent group)
+                          (:ref:`see format details <ped_file_format>`).
+                          Default: MF_1.
+      -rec_length REC_LENGTH
+                          Recombination length of the chromosome in Morgans
+                          (see :ref:`map file <map_file_format>`).
+                          Default: 1.00.
+      -mutation_rate MUTATION_RATE
+                          Mutation :ref:`probability <prob_freq_rate>`.
+                          Default: 1e-8.
+      -geno_error_prob GENO_ERROR_PROB
+                          Genotype error :ref:`probability <prob_freq_rate>`.
+                          Default: 0.0001.
+      -seq_error_prob SEQ_ERROR_PROB
+                          Sequence error :ref:`probability <prob_freq_rate>`.
+                          Must not be 0.
+                          Default: 0.001.
+      -pheno_penetrance_prob_file
+                          [PHENO_PENETRANCE_PROB_FILE ...]
+                          Phenotype penetrance :ref:`probability <prob_freq_rate>` file
+                          (:ref:`see format details <pheno_penetrance_prob_file_format>`).
 
+.. TODO: rename mutation_rate to mut_prob
 
-|Software| requires a pedigree file (``-ped_file``) and one or more genomic data files to run the analysis.
+|Software| requires a pedigree file (``-ped_file``) and
+one or more genomic data files to run the analysis.
 
-|Software| supports the following genomic data files: genotype files in the AlphaGenes format (``-geno_file``), sequence allele read in the AlphaGenes format (``-seq_file``), and binary Plink files (``-plink_file``). Use of binary Plink files requires the package ``alphaplinkpython``, which  can be installed via ``pip``, but is only stable for Linux. There are known issues with this package, so we do not advocate its use at the moment.
+|Software| supports the following genomic data files:
+genotype file in the AlphaGenes format (``-geno_file``),
+sequence allele read count file in the AlphaGenes format (``-seq_file``), and
+binary Plink file (``-plink_file``).
 
-Use the ``-start_snp`` and ``-stop_snp`` to run the analysis only on a subset of markers.
+When ``-x_chr`` is used the :ref:`pedigree file <ped_file_format>` and
+:ref:`genotype file <geno_file_format>` have specific requirements.
+Follow the links to respective file formats for more details.
 
-The input options in the form of ``[xxx ...]`` can take in more than one input file separated by space.
+|Software| also supports phenotype files (``-pheno_file``) and
+corresponding phenotype penetrance files (``-pheno_penetrance_prob_file``).
+Both must be provided for work with phenotypes.
 
-Output arguments 
-----------------
+The input options in the form of ``-opt [XYZ ...]``
+can accept more than one argument separated by spaces.
 
-::
+Use ``-start_snp`` and ``-stop_snp``
+to run the analysis only on a subset of :ref:`markers <markers>`.
 
-    Output options:
-      -out_file PREFIX      The output file prefix. All file outputs will be stored
-                            as "PREFIX.dosage.txt" and so on.
+.. _markers:
+
+.. note::
+
+    We use interchangeably the terms "marker(s)", "locus/loci", "SNP(s)",
+    or "site(s)", to refer to a specific position in the genome,
+    where we typically observe polymorphism in the population.
+
+|Software| supports specifying a number of model parameters,
+which are :ref:`probabilities <prob_freq_rate>` of different events or outcomes:
+alternative allele probabilities in the base population(s) (``-alt_allele_prob_file``),
+recombination length of the chromosome (``-rec_length``),
+
+.. TODO: rename mutation_rate to mut_prob
+
+mutation rate (``-mutation_rate``),
+genotype error probability (``-geno_error_prob``),
+sequence error probability (``-seq_error_prob``), and
+phenotype penetrance probabilities (``-pheno_penetrance_prob_file``).
+
+.. _robust_parameters:
+
+.. note::
+
+    The accuracy of |Software| results has been shown
+    to be quite robust to deviations in most of the model parameters,
+    so it might not be needed to change or estimate them from the input data;
+    at least unless large deviations from the defaults are known or expected.
+    Having said this, do explore what works best for your data and your aims!
+
+.. _prob_freq_rate:
+
+.. note::
+
+    We use the term "probability" to also represent the commonly used terms
+    "frequency" and "rate", to refer to the same concept of a value
+    between 0 and 1 that quantifies the likelihood or proportion
+    of a certain event or outcome.
+
+.. _output_options:
+
+Output options
+--------------
+
+.. parsed-literal::
+
+    Individuals:
+      -no_dosage            Suppress default output of :ref:`allele dosages <dosage_file_format>`.
+      -geno                 Call and output :ref:`genotypes <genotype_file_format>`.
+      -geno_threshold [GENO_THRESHOLD ...]
+                            Genotype calling threshold(s) from the genotype probabilities.
+                            Multiple space separated values allowed.
+                            Value(s) less than 1/3 are replaced by 1/3.
+                            Default: 1/3.
+      -geno_prob            Output :ref:`genotype probabilities <geno_prob_file_format>`.
+      -phased_geno_prob     Output :ref:`phased genotype probabilities <phased_geno_prob_file_format>`.
+      -hap                  Call and output :ref:`haplotypes <hap_file_format>`.
+                            Default: 1/2.
+      -hap_threshold [HAP_THRESHOLD ...]
+                            Haplotype calling threshold(s) from the phased genotype probabilities
+                            Multiple space separated values allowed.
+                            Value(s) less than 1/2 are replaced by 1/2.
+      -seg_prob             Output :ref:`segregation probabilities <seg_prob_file_format>`.
+      -pheno_prob           Output :ref:`phenotype probabilities <pheno_prob_file_format>`.
+
+    Prefix, order, and IO:
+      -out_file PREFIX      The output file prefix. All file outputs will be named
+                            as "PREFIX.OUTPUT.txt", where "OUTPUT" is the type of output
+                            (for example, "dosage" and "geno_prob").
       -out_id_order OUT_ID_ORDER
-                            Determines the order in which individuals are ordered
-                            in the output file based on their order in the
+                            Determines the order of individuals in the output
+                            file based on their order in the
                             corresponding input file. Individuals not in the input
                             file are placed at the end of the file and sorted in
                             alphanumeric order. These individuals can be suppressed
-                            with the "-out_id_only" option. Options: id, pedigree,
-                            genotypes, sequence, segregation. Default: id.
-      -out_id_only          Flag to suppress the individuals not present in
-                            the file used with "-out_id_order". It also suppresses "dummy"
-                            individuals.
+                            with the -out_id_only option. Accepted arguments for
+                            this option are: id, pedigree, genotypes, sequence, and
+                            segregation.
+                            Default: id.
+      -out_id_only          Suppress output for individuals not present in
+                            the file specified with -out_id_order. It also suppresses
+                            "dummy" individuals.
       -n_io_thread N_IO_THREAD
-                            Number of threads to use for input/output. Default: 1.
+                            Number of threads to use for input/output (IO).
+                            Default: 1.
 
+|Software| by default produces a :ref:`dosage file <dosage_file_format>`.
+Additional individual-level outputs can be requested with the options described above.
+The ``-geno_threshold`` and ``-hap_threshold``
+respectively control which genotypes and haplotypes are called.
+A threshold of 0.9 gives calls only if
+the probability for one genotype (or haplotype allele) is higher than 0.9.
+When the probability is lower than the threshold,
+the output is set to value :ref:`9 (missing) <zero_one_two_etc>`.
+Using a higher value will increase the accuracy of called genotypes (or haplotypes),
+but will result in fewer calls.
+Since there are three genotype states and two haplotype states,
+"best-guess" genotypes and haplotypes are
+respectively called with a threshold less than ``1/3`` and ``1/2``.
 
-    Peeling output options:
-      -no_dosage            Flag to suppress the dosage files.
-      -no_param             Flag to suppress writing the model parameter files.
-      -alt_allele_prob      Flag to write out the alternative allele frequencies for each metafounder.
-      -seg_prob             Flag to enable writing out the segregation probabilities.
-      -phased_geno_prob     Flag to enable writing out the phased genotype probabilities.
-      -geno_prob            Flag to enable writing out the genotype probabilities.
-      -pheno_prob          Flag to enable writing out the phenotype probabilities.
-      -hap                  Flag to call and write out the haplotypes.
-                            If the ``-hap_threshold`` parameter is not provided, the default haplotype calling threshold is set to 1/2.
-      -geno                 Flag to call and write out the genotypes.
-                            If the ``-geno_threshold`` parameter is not provided, the default genotype calling threshold is set to 1/3.
-      -geno_threshold [GENO_THRESHOLD ...]
-                            Genotype calling threshold(s). Multiple space separated values allowed.
-                            Value less than 1/3 will be replaced by 1/3.
-      -hap_threshold [HAP_THRESHOLD ...]
-                            Haplotype calling threshold(s). Multiple space separated values allowed.
-                            Value less than 1/2 will be replaced by 1/2.
-      -binary_call_file    Flag to write out the called genotype files as a
-                            binary plink output [Not yet implemented].
+The output order of individuals can be changed
+using the ``-out_id_order`` option,
+with additional control provided with the ``-out_id_only`` option.
+The latter option is not recommended for hybrid peeling or
+any combination of different input files.
 
-By default |Software| produces a dosage file and two model parameter files (genotype error rate and recombination rate). Creation of these files can be suppressed with the ``-no_dosage``, and ``-no_param`` options. |Software| can also write out the alternative allele frequencies per metafounder (*.alt_allele_prob.txt*) with ``-alt_allele_prob`` argument, the phased genotype probability file (*.phased_geno_prob.txt*) with the ``-phased_geno_prob`` argument and the segregation probability file (*.seg_prob.txt*) with the ``-seg_prob`` argument.
+The option ``-n_io_thread`` controls the number of threads/processes
+used by |Software|.
+|Software| uses additional threads to parse and format input and output files.
+Setting this option to a value greater than 1 is only recommended for very large files
+(i.e. >10,000 individuals).
 
-The ``-geno_threshold`` and ``-hap_threshold`` arguments respectively control which genotypes and haplotypes are called. A threshold of 0.9 will give calls only if the probability mass for one genotype (or haplotype) is higher than 0.9. Using a higher-value will increase the accuracy of called genotypes (or haplotypes), but will result in fewer called genotypes (or haplotypes). Since there are three genotypes states and two haplotype states, "best-guess" genotypes and haplotypes are respectively called with a threshold less than ``1/3`` and ``1/2``.
+.. _peeling_methods:
 
-``-binary_call_file`` option can be used to change the output to a plink binary format.
+Peeling methods
+---------------
 
-The order in which individuals are output can be changed by using the ``out_id_order`` option. This option changes the order in which individuals are written out to the order in which they were observed in the corresponding file. The ```-out_id_only`` option suppresses the output of dummy individuals (not recommended for hybrid peeling).
+.. parsed-literal::
 
-The argument ``-n_io_thread`` controls the number of threads/processes used by |Software|. |Software| uses additional threads to parse and format input and output files. Setting this option to a value greater than 1 is only recommended for very large files (i.e. >10,000 individuals).
+    Strategy:
+      -method METHOD        Peeling method: single or multi.
+                            Default: multi.
 
-Peeling arguments 
+    Single-locus options for the second stage of hybrid peeling:
+      -seg_file SEG_FILE    :ref:`Segregation probabilities file <seg_prob_file_format>`.
+      -seg_map_file SEG_MAP_FILE
+                            Map file for loci in the segregation probabilities file.
+
+|Software| supports three peeling strategies: single-locus, multi-locus, and hybrid.
+
+Single-locus peeling method does not use linkage information between loci in iterative peeling.
+It is fast, but not very accurate.
+
+Multi-locus peeling method runs multi-locus iterative peeling,
+which uses linkage information to increase accuracy and calculate segregation probabilities,
+but it is much slower than single-locus method.
+
+Hybrid peeling is useful in settings with
+a SNP genotypes with a limited number of markers and
+a sequence allele read counts from a large number of loci.
+In this setting, you can
+first run the multi-locus peeling method on
+SNP genotypes to estimate segregation probabilities, and
+then run the single-locus peeling method on
+sequence allele read counts and the segregation probabilities.
+In this second stage of hybrid peeling, provide:
+a ``-map_file`` with positions for loci in the sequence allele read count data,
+a ``-seg_file`` with segregation probabilities generated via multi-locus method, and
+a ``-seg_map_file`` with genetic positions for loci in the segregation probabilities file.
+This combination of options is not required in the standard multi-locus mode.
+
+.. _peeling_parameters:
+
+Peeling parameters
 ------------------
 
-::
+.. parsed-literal::
 
-    Mandatory peeling arguments:
-      -method METHOD        Program run type. Either "single" or "multi".
-    
-    Optional peeling arguments:
-      -n_cycle N_CYCLE    Number of peeling cycles. Default: 5.
+    Computational parameters:
+      -n_cycle N_CYCLE      Number of peeling cycles.
+                            Default: 5.
       -n_thread N_THREAD
-                            Number of threads to use. Default: 1.
-      -rec_length REC_LENGTH
-                            Estimated recombination length of the chromosome in Morgans.
-                            [Default 1.00]
+                            Number of threads to use.
+                            Default: 1.
 
-    Peeling control arguments:
-      -est_geno_error_prob  Flag to re-estimate the genotyping error rates after
-                            each peeling cycle.
-      -est_pheno_error_prob  Flag to re-estimate the phenotype error rates after
-                            each peeling cycle.
-      -est_seq_error_prob   Flag to re-estimate the sequencing error rates after
-                            each peeling cycle.
-      -est_rec_prob         Flag to re-estimate the recombination rates after
-                            each peeling cycle.
-      -est_alt_allele_prob  Flag to estimate the alternative allele frequencies using
-                            all observed genotypes prior to peeling.
-      -update_alt_allele_prob
-                            Flag to re-estimate the alternative allele frequencies
-                            for each metafounder after each peeling cycle.
-      -no_phase_founder     A flag phase a heterozygous allele in one of the
+    Estimation of model parameters:
+      -est_start_alt_allele_prob
+                            Estimate starting alternative allele probabilities
+                            from all inputted genomic data prior to peeling.
+      -est_alt_allele_prob  Estimate :ref:`alternative allele probabilities <alt_allele_prob_file_format>`
+                            after each peeling cycle.
+      -est_geno_error_prob  Estimate :ref:`genotype error probability <geno_error_prob_file_format>`
+                            after each peeling cycle.
+      -est_seq_error_prob   Estimate :ref:`sequence error probability <seq_error_prob_file_format>`
+                            after each peeling cycle.
+      -est_pheno_penetrance_prob
+                            Estimate :ref:`phenotype penetrance probabilities <pheno_penetrance_prob_file_format>`
+                            after each peeling cycle.
+      -no_phase_founder     Phase a heterozygous allele in one of the
                             founders (if such an allele can be found).
-      -x_chr            A flag to indicate that input data is for the X chromosome.
-                            
-    Genotype probability arguments:
-      -geno_error_prob GENO_ERROR_PROB
-                            Genotyping error rate. [Default 0.0001]
-      -seq_error_prob SEQ_ERROR_PROB
-                            Sequencing error rate. [Default 0.001]
-      -mutation_rate MUTATION_RATE
-                            mutation rate. [Default 1e-8]
 
-``-method`` controls whether the program is run in "single-locus" or "multi-locus" model. Single locus mode does not use linkage information to perform imputation. It is fast, but not very accurate. Multi-locus mode runs multi-locus iterative peeling which uses linkage information to increase accuracy and calculate segregation values.
+.. TODO: no_phase_founder is not documented - see https://github.com/AlphaGenes/AlphaPeel/issues/112
+.. TODO: which section should this option be in?
 
-For hybrid peeling, where a large amount (millions of segregating sites) of sequence allele read counts needs to be imputed, first run the program in multi-locus mode to generate a segregation file, and then run the program in single-locus mode with a known segregation file.
+Computational effort and speed of |Software| can be controlled with
+the number of peeling cycles (``-n_cycle``,
+increasing the number will marginally increase accuracy, but also runtime) and
+the number of threads (``-n_thread``, to reduce runtime on large datasets).
 
-The ``-geno_error_prob``, ``-seq_error_prob``, ``-mutation_rate`` and ``-rec_length`` arguments control some of the model parameters used in the model. ``-seq_error_prob`` must not be zero. |Software| is robust to deviations in genotyping error rate and sequencing error rate so it is not recommended to use these options unless large deviations from the default are known. Changing the ``-length`` argument to match the genetic map length can increase accuracy in some situations.
+..
+  TODO: delete these options as they are just making a mess - below is a clear and simple behaviour
+  -no_param             Suppress output of model parameter files.
+  -alt_allele_prob      Output :ref:`alternative allele probabilities <alt_allele_prob_file_format>`.
 
-The ``-est_geno_error_prob`` and ``-est_seq_error_prob`` options estimate the genotyping error rate and the sequencing error rate based on miss-match between observed and inferred states. This option is generally not necessary and can increase runtime. ``-est_alt_allele_prob`` estimates the alternative allele frequency for the base population before peeling using all available genotypes. This option can be useful if there are a large number of non-genotyped founders. ``-update_alt_allele_prob`` re-estimates the alternative allele frequencies per metafounder after each peeling cycle using the inferred genotype probabilities of the founders. 
+|Software| can estimate the model parameters from the input data.
+The :ref:`default or user provided input values<input_options>`
+are used as a starting point for estimation.
+See a note on :ref:`robustness of results <robust_parameters>`
+to these parameters.
 
-For a pedigree with multiple metafounders, the user has three options: (1) use ``-update_alt_allele_prob`` only, (2) use ``est_alt_allele_prob`` and ``-update_alt_allele_prob``, or (3) input estimates of the alternative allele frequencies for each metafounder via the ``-alt_allele_prob_file`` with or without ``-update_alt_allele_prob``.
+.. TODO: check for this behaviour for each parameter (output only when estimated)
 
-When ``-x_chrom`` is used, there are two requirements for input files: (1) The pedigree file must include sex information in the fourth column (0 indicates male and 1 indicates female). See the Pedigree File Format section for an example. (2) Male's genotype must be coded as {0,1}. See the Genotype file Format section for an example. Note: This option currently only considers the regions of the X chromosome excluding the pseudo-autosomal regions (PARs).
+When estimation options are used,
+the respective parameters are estimated after each peeling cycle and
+output to a file at the end.
+This process usually increases running times and
+might require additional peeling cycles to converge.
+The estimates are based on inferred states of the modelled events and
+their match/mismatch between observed and inferred states.
 
-Hybrid peeling arguments 
-------------------------
+Alternative allele probabilities are estimated (using ``-est_alt_allele_prob``)
+as half of the mean of estimated :ref:`allele dosage <dosage_file_format>`
+in the base population(s) (metafounders).
 
-::
+..
+  The estimates are constrained to be between 0.01 and 0.99
+  to avoid TODO: discuss with Evie how to word this.
 
-    Single locus arguments:
-      -seg_file SEG_FILE    A segregation probabilities file for hybrid peeling.
-      -seg_map_file SEG_MAP_FILE
-                            A map file for loci in the segregation probabilities file in hybrid peeling.
+This estimation can be warm-started with a sample estimate from inputted genomic data
+(using ``-est_start_alt_allele_prob``).
+Note that this sample estimate is not taking the pedigree structure into account,
+so it is a naive estimate and does not pertain to the pedigree base population(s)
+and hence ignores metafounders.
+Option ``-est_start_alt_allele_prob`` uses Newton optimisation,
+which also requires starting values.
+These starting values are by default 0.5,
+but can also be provided using ``-alt_allele_prob_file``.
 
-In order to run hybrid peeling the user needs to supply a ``-map_file`` which gives the genetic positions for the SNPs in the sequence allele read counts data supplied, a ``-seg_map_file`` which gives the genetic position for the SNPs in the segregation file, and a ``-seg_file`` which gives the segregation values generated via multi-locus iterative peeling. These arguments are not required for running in multi-locus mode.
+For a pedigree with :ref:`multiple metafounders <ped_file_format>`,
+there are three options to obtain metafounder-specific alternative allele probabilities:
+(1) use the default starting values of 0.5 for all loci and then
+``-est_alt_allele_prob``,
+(2) use ``-est_start_alt_allele_prob`` to use sample-based starting values and
+then ``-est_alt_allele_prob``, or
+(3) provide starting values using ``-alt_allele_prob_file`` and
+then ``-est_alt_allele_prob``.
+In all three cases,
+``-est_alt_allele_prob`` is optional.
+
+.. TODO: no_phase_founder is not documented / see above
+
+Error probabilities (using ``-est_geno_error_prob`` and ``-est_seq_error_prob``)
+are estimated as the proportion of mismatches between observed and inferred states.
+
+Phenotype penetrance probabilities (using ``-est_pheno_penetrance_prob``) are estimated
+from the average conditional probabilities of phenotype states for each phased genotype
+across phenotyped individuals. This follows Kinghorn (2003)
+A simple method to detect a single gene that determines a categorical trait with incomplete penetrance.
+Assoc. Advmt. Anim. Breed. Genet. 15:103-106.
+
+.. _file_formats:
 
 ============
 File formats
 ============
 
+.. _input_file_formats:
+
 Input file formats
 ------------------
+
+.. _ped_file_format:
 
 Pedigree file
 =============
 
-Each line of a pedigree file has three values, the individual's id, their father's id, and their mother's id. "0" represents an unknown id. Individuals with one unknown parent get internally assigned a dummy/unknown parent. Hence all individuals have both or none parents known. Individuals with two unknown parents are considered as founders and are internally allocated to a metafounder (unknown parent group) ``"MF_1"`` (or defined by the user through ``-main_metafounder``). Users can provide additional metafounders as shown below - these must start with ``"MF_"``.
+This file has one line with
+*recorded parents* for each individual.
+The file(s) should include all individuals present in other files
+and their known relatives present only in pedigree.
+Each line of a *pedigree* file has three values,
+the individual's ID,
+their father's ID, and
+their mother's ID.
+Unknown parent ID is encoded with ``0``.
+Individuals with one unknown parent are internally assigned a "dummy" parent.
+Therefore, all individuals have either both parents known or neither parent known.
+Individuals with two unknown parents are considered as founders and
+as such represent the base population of the pedigree.
+Internally, they are assigned to a metafounder (unknown parent group) ``MF_1``
+(or whatever is specified through ``-main_metafounder``).
+Users can define multiple base populations (metafounders) as shown below.
+The IDs of these metafounders must start with ``MF_``.
 
-Example:
+When working with the X chromosome,
+a fourth value is needed for individual's sex:
+``0`` for males and ``1`` for females.
+
+Example with four individuals across two generations:
 
 ::
 
@@ -188,7 +399,7 @@ Example:
   id3 id1 id2
   id4 id1 id2
 
-or
+Example with two metafounders:
 
 ::
 
@@ -197,63 +408,102 @@ or
   id3 id1 id2
   id4 id1 id2
 
-When working with X chromosome use this format - add sex information in the fourth column (0 indicates male and 1 indicates female):
+Example with sex information;
+id1 and id3 are males, while id2 and id4 are females:
 
 ::
 
-  id1 0 0 0 
+  id1 0 0 0
   id2 0 0 1
   id3 id1 id2 0
   id4 id1 id2 1
 
+.. _geno_file_format:
 
-Genotype file 
+Genotype file
 =============
 
-Genotype files contain the input genotypes for each individual. The first value in each line is the individual's id. The remaining values are the genotypes of the individual at each locus, either 0, 1, or 2 (or 9 if missing). The following examples gives the genotypes for four individuals genotyped on four markers each.
+This file has one line with
+*observed genotypes* for each genotyped individual.
+The file does not need to include all individuals present in other files.
+The first value in each line is the individual's ID.
+The remaining values are observed genotypes at each locus.
+Only loci on one chromosome should be provided!
 
-Example:
+.. _zero_one_two_etc:
+
+.. note::
+
+    |Software| works with bi-allelic loci with two *alleles*;
+    *reference (major)* allele ``a`` and
+    *alternative (minor)* allele ``A``.
+    The terms major and minor indicates their frequency in a population,
+    but this is not a requirement for |Software|.
+    These alleles are numerically encoded as ``0`` and ``1``, respectively.
+    Combining two alleles in a diploid individual gives three possible *genotypes*:
+    reference homozygote ``a/a``,
+    heterozygote ``a/A`` or ``A/a``, and
+    alternative homozygote ``A/A``.
+    When the origin of alleles that an individual inherited is known,
+    we have four *phased genotypes*: ``aa``, ``aA``, ``Aa``, and ``AA``,
+    where the *paternal allele* is listed first and
+    the *maternal allele* is listed second.
+    These genotypes are numerically encoded as ``0``, ``1``, and ``2``, respectively.
+    Missing alleles and genotypes are numerically encoded as ``9``.
+    The numerical codes are called *allele dosages*, because
+    they represent the number (dose) of alternative alleles.
+
+    When working with the X chromosome:
+    (1) *heterogametic genotypes* (for males in mammals (XY) and for females in birds (ZW))
+    should be coded as:
+    ``0`` (reference allele ``a`` on the X chromosome of the XY genotype),
+    ``1`` (alternative allele ``A`` on the X chromosome of the XY genotype), or
+    ``9`` (missing) and
+    (2) *Homogametic genotypes* (females in mammals (XX) and males in birds (ZZ))
+    should be coded as described above for autosomes
+    (since they have the XX genotype).
+
+Example with four individuals and their genotypes at four loci:
 
 ::
 
-  id1 0 2 9 0 
-  id2 1 1 1 1 
-  id3 2 0 2 0 
+  id1 0 2 9 0
+  id2 1 1 1 1
+  id3 2 0 2 0
   id4 0 2 1 0
 
-When working with X chromosome, male's genotype must be coded as {0,1}:
+Example with four individuals and their X chromosome genotypes at four loci;
+id1 and id3 are males, while id2 and id4 are females:
+
 ::
 
-  id1 0 1 9 0 
-  id2 1 1 1 1 
-  id3 1 0 1 0 
+  id1 0 1 9 0
+  id2 1 1 1 1
+  id3 1 0 1 0
   id4 0 2 1 0
 
-Phenotype file 
-==============
-
-Phenotype files contain the input phenotypes for each individual. The first value in each line is the individual's id. The remaining values are the phenotypes of the individual for specific trait, coded from 0. For example, a binary trait can be coded as 0 and 1, while a trait with three states can be coded as 0, 1, and 2. Remove any individuals with missing phenotypes from the file.
-
-Example:
-
-::
-
-  id1 0 
-  id2 1 
-  id3 1 
-  id4 0
+.. _seq_file_format:
 
 Sequence allele read counts file
 ================================
 
-The sequence allele read counts file has two lines for each individual. The first line gives the individual's id and read counts for the reference allele. The second line gives the individual's id and allele read counts for the alternative allele.
+This file has two lines with
+*observed allele read counts* for each sequenced individual.
+The file does not need to include all individuals present in other files.
+The first line gives the individual's ID and read counts for the :ref:`reference allele <zero_one_two_etc>` at each locus.
+The second line gives the individual's ID and allele read counts for the :ref:`alternative allele <zero_one_two_etc>` at each locus.
 
-Example:
+.. TODO: work with Yuni on X seq data input
+
+The same format works for the autosomes and the X chromosome.
+Only loci on one chromosome should be provided!
+
+Example with four individuals and their allele read counts at four loci:
 
 ::
 
-  id1 4 0 0 7 # Reference allele for id1
-  id1 0 3 0 0 # Alternative allele for id1
+  id1 4 0 0 7 # Reference allele read counts for id1
+  id1 0 3 0 0 # Alternative allele read counts for id1
   id2 1 3 4 3
   id2 1 1 6 2
   id3 0 3 0 1
@@ -261,17 +511,60 @@ Example:
   id4 2 0 6 7
   id4 0 7 7 0
 
-Binary plink file
+.. _pheno_file_format:
+
+Phenotype file
+==============
+
+This file has one or multiple lines with
+*observed phenotypes* for each phenotyped individual.
+Multiple lines per individual support repeated phenotyping.
+The file does not need to include all individuals present in other files.
+The first value in each line is the individual's ID.
+The remaining values are the phenotypes of the individual for a specific trait,
+coded from ``0`` onwards.
+For example, a binary trait should be coded as ``0`` and ``1``,
+while a trait with three states should be coded as ``0``, ``1``, and ``2``
+(current phenotype functionality works only with one locus and one trait).
+
+Example with four individuals and their phenotypes for a binary trait:
+
+::
+
+  id1 0
+  id2 1
+  id3 1
+  id4 0
+
+.. _plink_file_format:
+
+Binary Plink file
 =================
 
-Binary Plink files are supported using the package ``AlphaPlinkPython``. The pedigree supplied by the *.fam* file will be used if a pedigree file is not supplied. Otherwise, the pedigree file will be used and the *.fam* file will be ignored.
+This file is supported through the package ``AlphaPlinkPython``,
+which can be installed via ``pip``, but is only stable for Linux.
+There are known issues with this package,
+so we do not advocate its use at the moment.
+The pedigree supplied by the ``.fam`` file will be used if a pedigree file is not supplied.
+Otherwise, the pedigree file will be used and the ``.fam`` file will be ignored.
 
-Map file 
+.. _map_file_format:
+
+Map file
 ========
 
-The map file gives the chromosome number, the marker name, and the base pair position for each marker in two columns. Only markers on one chromosome should be provided! 
+This file has one line with
+*genome information* for each :ref:`locus <markers>`.
+The file should include all loci present in other files.
+Each line of a *map* file has three values,
+the chromosome number,
+the locus name, and
+the physical position (in base-pairs).
+Only loci on one chromosome should be provided!
 
-Example:
+.. TODO: mention here how we convert physical positions to genetic positions (Morgans) and interaction? with -rec_length
+
+Example with four SNP loci on chromosome 1:
 
 ::
 
@@ -280,136 +573,284 @@ Example:
   1 snp_c 65429279
   1 snp_d 107421759
 
-Alternative allele probability file
-===================================
+.. TODO: how does seg_map_file look like?
 
-The alternative allele probability file allows for user-defined population alternative allele frequencies. This file contains the metafounder group denoted MF_x, where x is by default "1" but see ``-main_metafounder``, followed by alternative allele frequencies for all the markers. In case of multiple metafounders, provide multiple rows in the file. The default starting alternative allele frequencies are 0.5 for each marker. If you don't have information for some markers, provide 0.5 for these in the file.
-
-Example:
-
-::
-
-  MF_1 0.30 0.21 0.44 0.24
-
-Or
-
-::
-
-  MF_1 0.30 0.21 0.44 0.24
-  MF_2 0.40 0.34 0.25 0.40
-
-Phenotype penetrance file
-=========================
-
-The phenotype penetrance file allows for user flexibility to include phenotype information. This file contains the conditional probability table for true phenotype given the true genotype. Each column represents the different phenotype states (order from 0 to total number of states), and each row represents the genotype states in order the aa, aA, Aa, AA. Below, we provide an example for a monogenic recessive, binary trait.
-
-Example:
-
-::
-
-  0.9 0.1
-  0.9 0.1
-  0.9 0.1
-  0.1 0.9
+.. _output_file_formats:
 
 Output file formats
 -------------------
 
-Phase file
-==========
-
-The phase file gives the phased haplotypes (either 0 or 1) for each individual in two lines. For individuals where we can determine the haplotype of origin, the first line will provide information on the paternal haplotype, and the second line will provide information on the maternal haplotype.
-
-Example:
-
-::
-
-  id1 0 1 9 0 # Paternal haplotype
-  id1 0 1 9 0 # Maternal haplotype
-  id2 1 1 1 0
-  id2 0 0 0 1
-  id3 1 0 1 0
-  id3 1 0 1 0 
-  id4 0 1 0 0
-  id4 0 1 1 0
-
-Genotype probability file
-=========================
-
-The haplotype file (*.phased_geno_prob.txt*) provides the (phased) allele probabilities for each locus. There are four lines per individual containing the allele probability for the (aa, aA, Aa, AA) alleles where the paternal allele is listed first, and where *a* is the reference (or major) allele and *A* is the alternative (or minor) allele.
-
-Example:
-
-::
-
-  id1    0.9998    0.0001    0.0001    1.0000
-  id1    0.0000    0.4999    0.4999    0.0000
-  id1    0.0000    0.4999    0.4999    0.0000
-  id1    0.0001    0.0001    0.0001    0.0000
-  id2    0.0000    1.0000    0.0000    1.0000
-  id2    0.9601    0.0000    0.0455    0.0000
-  id2    0.0399    0.0000    0.9545    0.0000
-  id2    0.0000    0.0000    0.0000    0.0000
-  id3    0.9998    0.0001    0.0001    1.0000
-  id3    0.0000    0.4999    0.4999    0.0000
-  id3    0.0000    0.4999    0.4999    0.0000
-  id3    0.0001    0.0001    0.0001    0.0000
-  id4    1.0000    1.0000    0.0000    1.0000
-  id4    0.0000    0.0000    0.0000    0.0000
-  id4    0.0000    0.0000    0.0000    0.0000
-  id4    0.0000    0.0000    1.0000    0.0000
+.. _dosage_file_format:
 
 Dosage file
 ===========
 
-The dosage file gives the expected allele dosage for the alternative (or minor) allele for each individual. The first value in each line is the individual ID. The remaining values are the allele dosages at each loci. These values will be between 0 and 2.
+The ``.dosage.txt`` file contains *expected dosages for the alternative allele*
+for each individual.
+These expected dosages are obtained by
+(1) taking the :ref:`allele dosages <zero_one_two_etc>` (``0``, ``1``, and ``2``)
+of each individual at each locus,
+(2) weighting them with corresponding :ref:`genotype probabilities <geno_prob_file_format>`, and
+(3) summing the weighted dosages.
+There is one line per individual.
+The first value in each line is the individual ID.
+The remaining values are allele dosages at each locus.
+These values will be between ``0`` and ``2``, inclusive
+(:ref:`see the note on encoding alleles and genotypes <zero_one_two_etc>`).
 
-Example:
+Example with four individuals and four loci:
 
 ::
 
-  1    0.0003    1.0000    1.0000    0.0001
-  2    1.0000    0.0000    1.0000    0.0000
-  3    0.0003    1.0000    1.0000    0.0001
-  4    0.0000    0.0000    2.0000    0.0000
+  id1 0.2089 1.7820 1.4725 0.0000
+  id2 1.0000 1.0000 1.0000 0.9999
+  id3 0.8293 1.1329 1.9999 0.0000
+  id4 0.0001 1.9999 1.0000 0.0000
+
+.. _genotype_file_format:
+
+Genotype file
+=============
+
+The ``.geno_THRESHOLD.txt`` file contains *called genotypes* for each individual
+for each specified threshold (``-geno_threshold THRESHOLD``).
+There is one line per individual.
+The first value in each line is the individual ID.
+The remaining values are called genotypes at each locus,
+encoded as ``0``, ``1``, and ``2``, or ``9`` when
+the probability is to low to make the call
+(:ref:`see the note on encoding alleles and genotypes <zero_one_two_etc>`).
+
+Example with four individuals and four loci:
+
+::
+
+  id1 0 2 1 0
+  id2 1 1 1 1
+  id3 1 1 2 0
+  id4 0 2 1 0
+
+.. _geno_prob_file_format:
+
+Genotype probability file
+=========================
+
+The ``.geno_prob.txt`` file contains *genotype probabilities* for each individual.
+
+.. TODO: remove the empty lines in the output files? (4 will be 3 in text!)
+
+There are four lines per individual
+(an empty line and three lines with probabilities for
+``aa``, ``aA`` or ``Aa``, and ``AA`` genotypes).
+The first value in each line is the individual ID.
+The remaining values are genotype probabilities at each locus.
+
+Example with four individuals and four loci:
+
+::
+
+  id1 0.7912 0.0000 0.0000 1.0000
+  id1 0.2088 0.2179 0.5274 0.0000
+  id1 0.0000 0.7820 0.4725 0.0000
+
+  id2 0.0000 0.0000 0.0000 0.0001
+  id2 1.0000 1.0000 1.0000 0.9999
+  id2 0.0000 0.0000 0.0000 0.0000
+
+  id3 0.3784 0.2171 0.0000 1.0000
+  id3 0.4140 0.4329 0.0001 0.0000
+  id3 0.2076 0.3500 0.9999 0.0000
+
+  id4 0.9999 0.0000 0.0000 1.0000
+  id4 0.0001 0.0001 0.9999 0.0000
+  id4 0.0000 0.9999 0.0000 0.0000
+
+.. _phased_geno_prob_file_format:
+
+Phased genotype probability file
+================================
+
+The ``.phased_geno_prob.txt`` file contains *phased genotype probabilities* for each individual.
+
+.. TODO: remove the empty lines in the output files? (5 will be 4 in text!)
+
+There are five lines per individual
+(an empty line and four lines with probabilities for
+``aa``, ``aA``, ``Aa``, and ``AA`` phased genotypes).
+The first value in each line is the individual ID.
+The remaining values are phased genotype probabilities at each locus.
+
+Example with four individuals and four loci:
+
+::
+
+  id1 0.7912 0.0000 0.0000 1.0000
+  id1 0.1044 0.1090 0.2637 0.0000
+  id1 0.1044 0.1090 0.2637 0.0000
+  id1 0.0000 0.7820 0.4725 0.0000
+
+  id2 0.0000 0.0000 0.0000 0.0001
+  id2 0.3764 0.6611 0.0000 0.9628
+  id2 0.6236 0.3388 1.0000 0.0371
+  id2 0.0000 0.0000 0.0000 0.0000
+
+  id3 0.3784 0.2171 0.0000 1.0000
+  id3 0.4140 0.0000 0.0001 0.0000
+  id3 0.0000 0.4328 0.0000 0.0000
+  id3 0.2076 0.3500 0.9999 0.0000
+
+  id4 0.9999 0.0000 0.0000 1.0000
+  id4 0.0000 0.0000 0.2912 0.0000
+  id4 0.0000 0.0000 0.7088 0.0000
+  id4 0.0000 0.9999 0.0000 0.0000
+
+
+.. _hap_file_format:
+
+Phase / haplotype file
+======================
+
+The ``.hap_THRESHOLD.txt`` file contains *called haplotypes* for each individual.
+There are two lines per individual,
+one for each of the paternal and maternal haplotypes of the individual.
+The first value in each line is the individual ID.
+The remaining values are called alleles at each locus,
+encoded as ``0`` and ``1``, or ``9`` when
+the probability is to low to make the call
+(:ref:`see the note on encoding alleles and genotypes <zero_one_two_etc>`).
+For individuals for whom the allele/haplotype of origin can be determined,
+the first line provides information on the paternal haplotype, and
+the second line provides information on the maternal haplotype.
+
+Example with four individuals and four loci:
+
+::
+
+  id1 0 1 1 0 # Paternal haplotype
+  id1 0 1 1 0 # Maternal haplotype
+  id2 1 0 1 0
+  id2 0 1 0 1
+  id3 0 1 1 0
+  id3 1 0 1 0
+  id4 0 1 1 0
+  id4 0 1 0 0
+
+.. _seg_prob_file_format:
 
 Segregation file
 ================
 
-The segregation file gives the joint probability of each pattern of inheritance. There are four lines for each individual representing the probability of inheriting: 
+The ``.seg_prob.txt`` file contains *segregation probabilities* for each individual.
+There are four lines per individual,
+corresponding to the four possible patterns of segregation (inheritance):
 
-  1. the grand **paternal** allele from the father and the grand **paternal** allele from the mother
-  2. the grand **paternal** allele from the father and the grand **maternal** allele from the mother
-  3. the grand **maternal** allele from the father and the grand **paternal** allele from the mother
-  4. the grand **maternal** allele from the father and the grand **maternal** allele from the mother
+  1. The grand *paternal* allele from the father and
+     the grand *paternal* allele from the mother: :math:`Pr(F_{p,-} \& M_{p,-})`,
+  2. The grand *paternal* allele from the father and
+     the grand *maternal* allele from the mother: :math:`Pr(F_{p,-} \& M_{-,m})`,
+  3. The grand *maternal* allele from the father and
+     the grand *paternal* allele from the mother: :math:`Pr(F_{-,m} \& M_{p,-})`, and
+  4. The grand *maternal* allele from the father and
+     the grand *maternal* allele from the mother: :math:`Pr(F_{-,m} \& M_{-,m})`.
 
-Example:
+The symbols above mean the following:
+``Pr()`` probability,
+``F`` father,
+``M`` mother,
+``p`` *paternal* allele,
+``m`` *maternal* allele, and
+``-`` the allele that was not inherited.
+
+.. TODO: Do we need a diagram for this maybe even show the 4 cases so we bring home the message!?
+
+The first value in each line is the individual ID.
+The remaining values are segregation probabilities at each locus.
+
+Example with four individuals and four loci:
 
 ::
 
-  id1    1.0000    0.9288    0.9583    0.9834
-  id1    0.0000    0.0149    0.0000    0.0000
-  id1    0.0000    0.0554    0.0417    0.0166
-  id1    0.0000    0.0009    0.0000    0.0000
-  id2    0.9810    0.9842    1.0000    0.9971
-  id2    0.0174    0.0158    0.0000    0.0013
-  id2    0.0016    0.0000    0.0000    0.0016
-  id2    0.0000    0.0000    0.0000    0.0000
-  id3    0.0164    0.0149    0.0000    0.0065
-  id3    0.9259    0.9288    0.9582    0.9769
-  id3    0.0010    0.0009    0.0000    0.0001
-  id3    0.0567    0.0554    0.0417    0.0165
-  id4    0.0002    0.0000    0.0002    0.0004
-  id4    0.0015    0.0000    0.0019    0.0041
-  id4    0.1189    0.1179    0.1052    0.0834
-  id4    0.8794    0.8821    0.8927    0.9122
+  id1 0.2500 0.2500 0.2500 0.2500
+  id1 0.2500 0.2500 0.2500 0.2500
+  id1 0.2500 0.2500 0.2500 0.2500
+  id1 0.2500 0.2500 0.2500 0.2500
+  id2 0.2500 0.2500 0.2500 0.2500
+  id2 0.2500 0.2500 0.2500 0.2500
+  id2 0.2500 0.2500 0.2500 0.2500
+  id2 0.2500 0.2500 0.2500 0.2500
+  id3 0.3356 0.3894 0.5000 0.4390
+  id3 0.1644 0.1106 0.0000 0.0610
+  id3 0.3356 0.3894 0.5000 0.4390
+  id3 0.1644 0.1106 0.0000 0.0610
+  id4 0.2046 0.1953 0.2760 0.3914
+  id4 0.2954 0.3047 0.2240 0.1086
+  id4 0.2046 0.1953 0.2760 0.3914
+  id4 0.2954 0.3047 0.2240 0.1086
 
-Model parameter files
-=====================
+.. _pheno_prob_file_format:
 
-|Software| outputs four model parameter files: *.alt_allele_prob.txt*, *.seq_error_prob.txt*, *.geno_error_prob.txt*, *.rec_prob.txt*. These give the alternative allele frequency, sequencing error rates, genotyping error rates and the recombination rates used. In the *.alt_allele_prob.txt*, there is a column per metafounder with an alternative allele frequency for each marker. Here, all values will range from 0.01 to 0.99. The other three files contain a single column with an entry for each marker. By default, |Software| will output *.seq_error_prob.txt*, *.geno_error_prob.txt* and *.rec_prob.txt*. The *.alt_allele_prob.txt* will only be outputted with the argument ``-alt_allele_prob``.
+Phenotype probability file
+==========================
 
-Example ``.alt_allele_prob.txt`` file for two metafounders and four loci:
+The ``.pheno_prob.txt`` file contains *phenotype probabilities* for each individual.
+
+.. TODO: remove the empty lines in the output files? (1+k will be k in text!)
+
+There are ``1+k`` lines per individual
+(an empty line and ``k`` lines with probabilities for ``0:k`` phenotypes).
+The first value in each line is the individual ID.
+The remaining values are phenotype probabilities
+(current phenotype functionality works only with one locus and one trait).
+
+Example with four individuals and two phenotype states for a binary trait:
+
+::
+
+  id1 0.9000
+  id1 0.1000
+
+  id2 0.9000
+  id2 0.1000
+
+  id3 0.2453
+  id3 0.7547
+
+  id4 0.9000
+  id4 0.1000
+
+.. _param_file_format:
+
+Parameter file formats
+----------------------
+
+.. _alt_allele_prob_file_format:
+
+Alternative allele probability file
+===================================
+
+The ``.alt_allele_prob.txt`` file contains *alternative allele probabilities*
+for each base population (metafounder) and each locus.
+There is one line per locus, with one optional top/header line.
+The header contains the metafounder ID(s),
+which can be skipped when there is just one metafounder / no metafounders.
+The remaining lines contain the metafounder-specific alternative allele probabilities for each locus.
+The file should include all metafounders present in pedigrees.
+Any missing values, or whole metafounder columns, default to 0.5 for all loci.
+If you do not have information for some loci, provide 0.5 for those loci.
+The file format is identical whether inputted via ``-alt_allele_prob_file`` or
+outputted from estimation using ``-est_start_alt_allele_prob`` or ``-est_alt_allele_prob``.
+
+Example with no metafounder and four loci:
+
+::
+
+  0.468005
+  0.195520
+  0.733061
+  0.145847
+
+
+Example with two metafounders and four loci:
 
 ::
 
@@ -419,5 +860,67 @@ Example ``.alt_allele_prob.txt`` file for two metafounders and four loci:
   0.733061  0.509849
   0.145847  0.090000
 
+.. _geno_error_prob_file_format:
 
-.. |Software| replace:: AlphaPeel
+Genotype error probability file
+===============================
+
+The ``.geno_error_prob.txt`` file contains *genotype error probabilities* for each locus.
+There is one line per locus with one value.
+
+Example with four loci:
+
+::
+
+  0.050000
+  0.050000
+  0.000100
+  0.000100
+
+.. _seq_error_prob_file_format:
+
+Sequence error probability file
+===============================
+
+The ``.seq_error_prob.txt`` file contains *sequence error probabilities* for each locus.
+There is one line per locus with one value.
+
+Example with four loci:
+
+::
+
+  0.000137
+  0.000100
+  0.000362
+  0.000100
+
+.. _pheno_penetrance_prob_file_format:
+
+Phenotype penetrance probability file
+=====================================
+
+This ``.pheno_penetrance_prob.txt`` file contains *phenotype penetrance probabilities*
+for each distinct genotype impacting a phenotype.
+These probabilities encode the relationship between genotypes and phenotypes.
+The file should include all phenotypes present in phenotype files
+(current functionality works only with one locus and one trait).
+There are four lines per locus,
+containing conditional probabilities of
+all phenotypes for a given *phased genotype*,
+including phenotyping errors or other deviations.
+Each column represents a different phenotype state
+(ordered from ``0`` to the total number of states), and
+each row represents the :ref:`phased genotypes <zero_one_two_etc>`
+(``aa``, ``aA``, ``Aa``, and ``AA``).
+That is, the values within a row
+form a conditional probability distribution
+of phenotypes for the corresponding phased genotype.
+
+Example for a monogenic recessive binary trait with 10% phenotyping error:
+
+::
+
+  0.9 0.1
+  0.9 0.1
+  0.9 0.1
+  0.1 0.9


### PR DESCRIPTION
I was always annoyed by the usage section since it was confusing us and was not consistent. I have now completely overhauled it and strived to describe one thing in one place and cross-link where needed.

I also went and sorted all options according to their input, output, peeling methods, and peeling parameters. 

Then I went through all input file formats (in the order listed in input section).

Then I went through all output file formats (in the order listed in output section).

Then I went through all peeling parameters file formats (in the order listed in peeling parameters section).

This was helpful because it points out things that are inputted, outputted, how peeling methods are run, and how we can tweak peelling parameters.

It also shows areas that we should polish (some option renames) or check.

There is a number of simple TODOs for us to sort out! I will today work with @RosCraddock on the allele prob estimation parts and pheno penetrance part.